### PR TITLE
[ADD] Github Activity Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,11 @@ From [isitmaintained.com](http://isitmaintained.com):
 [![DenverCoder1's github streak](https://github-readme-streak-stats.herokuapp.com/?user=Naereen&theme=blue-green)](https://github.com/DenverCoder1/github-readme-streak-stats)
 ```
 
+[![x33lyS's github activity graph](https://activity-graph.herokuapp.com/graph?username=x33lyS&theme=react-dark)](https://github.com/ashutosh00710/github-readme-activity-graph)
+```markdown
+[![x33lyS's github activity graph](https://activity-graph.herokuapp.com/graph?username=x33lyS&theme=react-dark)](https://github.com/ashutosh00710/github-readme-activity-graph)
+```
+
 ### GitHub Stars Sparklines
 [![Sparkline](https://stars.medv.io/Naereen/badges.svg)](https://stars.medv.io/Naereen/badges)
 ```markdown


### PR DESCRIPTION
Add github activity graph from https://github.com/Ashutosh00710/github-readme-activity-graph for a readme github profil

Exemple:
![badges_graph](https://user-images.githubusercontent.com/71019197/191759232-677e0079-e895-4faa-94d2-8a67fb4c167d.png)
