### PR TITLE
Remove broken contributors over time badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,12 +573,6 @@ GoDoc reference (`godoc.org/:user/go/:repo`):
 [![Stargazers over time](https://starchart.cc/Naereen/badges.svg)](https://starchart.cc/Naereen/badges)
 ```
 
-### Github Contributors over time
-[![Contributors over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=Naereen/badges)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=Naereen/badges)
-```markdown
-[![Contributors over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=Naereen/badges)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=Naereen/badges)
-```
-
 ### GitHub watchers
 [![GitHub watchers](https://img.shields.io/github/watchers/Naereen/StrapDown.js.svg?style=social&label=Watch&maxAge=2592000)](https://GitHub.com/Naereen/StrapDown.js/watchers/)
 ```markdown


### PR DESCRIPTION
Resolves #71.

This issue has been around since Sept 29th, 2024, and has not been resolved by the owner. See https://github.com/api7/contributor-graph/issues/231. I looked around for a replacement, but found no suitable one.

For this reason, I think the badge should be removed.